### PR TITLE
Mark as compatible with Gnome 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Disable all GNOME built-in gestures. Useful for kiosks and touch screen apps.",
   "uuid": "disable-gestures-2021@verycrazydog.gmail.com",
   "shell-version": [
-    "3.36"
+    "3.36", "40.0"
   ],
   "url": "https://github.com/VeryCrazyDog/gnome-disable-gestures"
 }


### PR DESCRIPTION
This extension works fine on gnome 40, but Gnome 40 doesn't allow extensions that are not explicitly marked as compatible with it.